### PR TITLE
Add negative current reading handling

### DIFF
--- a/src/INA3221.cpp
+++ b/src/INA3221.cpp
@@ -416,7 +416,8 @@ int32_t INA3221::getShuntVoltage(ina3221_ch_t channel) {
 
     // instead of bit-shifting, (which would break the signed integer signing,) divide by 8 to remove the (reserved) last 3 least-significant bits
     // 1 LSB = 40uV
-    res = (int32_t)(val_raw / 8) * 40;
+    res = (int32_t)(val_raw);
+    res = (res / 8) * 40;
 
     return res;
 }

--- a/src/INA3221.cpp
+++ b/src/INA3221.cpp
@@ -396,7 +396,7 @@ void INA3221::setCurrentSumDisable(ina3221_ch_t channel) {
 }
 
 int32_t INA3221::getShuntVoltage(ina3221_ch_t channel) {
-    int32_t res;
+    int16_t res;
     ina3221_reg_t reg;
     uint16_t val_raw = 0;
 
@@ -416,7 +416,7 @@ int32_t INA3221::getShuntVoltage(ina3221_ch_t channel) {
 
     // instead of bit-shifting, (which would break the signed integer signing,) divide by 8 to remove the (reserved) last 3 least-significant bits
     // 1 LSB = 40uV
-    res = (int32_t)(val_raw);
+    res = (int16_t)(val_raw);
     res = (res / 8) * 40;
 
     return res;

--- a/src/INA3221.cpp
+++ b/src/INA3221.cpp
@@ -416,8 +416,7 @@ int32_t INA3221::getShuntVoltage(ina3221_ch_t channel) {
 
     // instead of bit-shifting, (which would break the signed integer signing,) divide by 8 to remove the (reserved) last 3 least-significant bits
     // 1 LSB = 40uV
-    res = (int16_t)(val_raw);
-    res = (res / 8) * 40;
+    res = (int16_t)(val_raw) / 8 * 40;
 
     return res;
 }


### PR DESCRIPTION
Current measurements come from the INA3221 as signed 16-bit integers and require a division-by-8 to purge some reserved bits at the LSB end of the packet.  Changed variables and handling of the bit-shift to preserve the signing bit so negative current values now display correctly.