### PR TITLE
Fix higher currents reporting negative/wrong

### DIFF
--- a/src/INA3221.h
+++ b/src/INA3221.h
@@ -288,7 +288,7 @@ class INA3221 {
     void setCurrentSumDisable(ina3221_ch_t channel);
 
     // Gets shunt voltage in uV.
-    int16_t getShuntVoltage(ina3221_ch_t channel);
+    int32_t getShuntVoltage(ina3221_ch_t channel);
 
     // Gets warning alert flag.
     bool getWarnAlertFlag(ina3221_ch_t channel);
@@ -297,7 +297,7 @@ class INA3221 {
     bool getCritAlertFlag(ina3221_ch_t channel);
 
     // Estimates offset voltage added by the series filter resitors
-    int16_t estimateOffsetVoltage(ina3221_ch_t channel, uint16_t busVoltage);
+    int32_t estimateOffsetVoltage(ina3221_ch_t channel, uint16_t busVoltage);
 
     // Gets current in mA.
     float getCurrent(ina3221_ch_t channel);


### PR DESCRIPTION
This change to 32bit has been working for me on my custom Meshtastic firmware build for about a week now.
Prior to this any larger positive current values would suddenly invert, and read as a negative value.

I've verified that the new values match my multimeter.

Although this isn't my preferred method to fix the issue, we have a public function which could be being used outside the library.

If `getShuntVoltage` was a private method my preference would be to have kept it int_16, and moved the multiplication from inside `getShuntVoltage` to everywhere which uses the returned µV value as they all convert to float.

However, it's public so could be being used directly and changing the type is obvious to everyone using this that something has changed.

This fixes meshtastic/firmware#5933